### PR TITLE
CI: configure changelog check to also run on labeled, unlabeled

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -2,6 +2,7 @@ name: check-changelog
 
 on:
   pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 jobs:
   validate-fragment:


### PR DESCRIPTION
required to retrigger the validate-fragment job when the no-changelog-entry-required label is added/removed