### PR TITLE
Fix: latex equations not rendered

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
 
 myst_enable_extensions = [
     "colon_fence",
+    "dollarmath",
 ]
 templates_path = ["_templates"]
 autosummary_generate = True


### PR DESCRIPTION
The switch to myst parser requires activating an extension to render equations surrounded by $...$.

closes MaMMoS-project/management#368