### PR TITLE
Fix: mammos-ai missing in overview, examples and API

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,14 +14,14 @@ help:
 
 prepare:
 	mkdir -p packages
-	for PKG in mammos-analysis mammos-dft mammos-entity mammos-mumag mammos-spindynamics mammos-units ; do \
+	for PKG in mammos-ai mammos-analysis mammos-dft mammos-entity mammos-mumag mammos-spindynamics mammos-units ; do \
 		git clone --branch latest --depth 1 "https://github.com/mammos-project/$$PKG.git" packages/$$PKG || (cd packages/$$PKG && git pull --rebase) ;\
 		rsync -a packages/$$PKG/examples/ source/examples/$$PKG ;\
 	done
 	rsync -a ../examples/ source/demonstrator/
 
 prepare-local:
-	for PKG in mammos-analysis mammos-dft mammos-entity mammos-mumag mammos-spindynamics mammos-units ; do \
+	for PKG in mammos-ai mammos-analysis mammos-dft mammos-entity mammos-mumag mammos-spindynamics mammos-units ; do \
 		rsync -a ../../$$PKG/examples/ source/examples/$$PKG;\
 	done
 	rsync -a ../examples/ source/demonstrator/

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -5,6 +5,7 @@ API Reference
    :toctree: .
    :recursive:
 
+   mammos_ai
    mammos_analysis
    mammos_dft
    mammos_entity

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -11,6 +11,7 @@ Further examples for the individual packages are available in these tutorials:
 .. toctree::
    :maxdepth: 2
 
+   mammos-ai/index
    mammos-analysis/index
    mammos-dft/index
    mammos-entity/index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,6 +31,10 @@ running the examples for the individual packages interactively in the cloud.
      - :doc:`Demonstrator <demonstrator/index>`
      - –
      - |binder-mammos-1| |binder-mammos-2|
+   * - `mammos-ai <https://github.com/mammos-project/mammos-ai>`__
+     - :doc:`examples/mammos-ai/index`
+     - :doc:`api/mammos_ai`
+     - |binder-ai-1| |binder-ai-2|
    * - `mammos-analysis <https://github.com/mammos-project/mammos-analysis>`__
      - :doc:`examples/mammos-analysis/index`
      - :doc:`api/mammos_analysis`
@@ -60,6 +64,10 @@ running the examples for the individual packages interactively in the cloud.
           :target: https://mybinder.org/v2/gh/mammos-project/mammos/latest?urlpath=lab%2Ftree%2Fexamples
 .. |binder-mammos-2| image:: /_static/badge-launch-binder2.svg
           :target: https://notebooks.mpcdf.mpg.de/binder/v2/gl/mammos-project%2Fmammos/latest?urlpath=lab%2Ftree%2Fexamples
+.. |binder-ai-1| image:: /_static/badge-launch-binder.svg
+          :target: https://mybinder.org/v2/gh/mammos-project/mammos-ai/latest?urlpath=lab%2Ftree%2Fexamples
+.. |binder-ai-2| image:: /_static/badge-launch-binder2.svg
+          :target: https://notebooks.mpcdf.mpg.de/binder/v2/gl/mammos-project%2Fmammos-ai/latest?urlpath=lab%2Ftree%2Fexamples
 .. |binder-analysis-1| image:: /_static/badge-launch-binder.svg
           :target: https://mybinder.org/v2/gh/mammos-project/mammos-analysis/latest?urlpath=lab%2Ftree%2Fexamples
 .. |binder-analysis-2| image:: /_static/badge-launch-binder2.svg


### PR DESCRIPTION
closes #61